### PR TITLE
fix(ras): fix text angle render

### DIFF
--- a/src/ras.rs
+++ b/src/ras.rs
@@ -71,7 +71,7 @@ impl Font {
                 StrokeStyle {
                     line_width: stroke_width / factor,
                     line_cap: LineCap::default(),
-                    line_join: LineJoin::default(),
+                    line_join: LineJoin::Miter(4.0),
                 },
             );
             filler.offset();


### PR DESCRIPTION
当glyph path中存在角度较小的尖角，并且设置较大的stroke-width的时候会出现尖角突出过长，违背了本身的拓扑关系，这种情况和[stroke-linejoin](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linejoin#miter)及[stroke-miterlimit](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-miterlimit)相关。pathfinder默认miterlimit为10，缩小这个值可以改善尖角渲染的问题，现保持与SVG spec一致。