### PR TITLE
feat(ras): expose stroke style param

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ unicode-normalization = { version = "0.1.19", optional = true }
 unicode-script = { version = "0.5.4", optional = true }
 usvg = { version = "0.22.0", optional = true }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", tag = "v0.2.0", optional = true }
-woff2 = { git = "https://github.com/zimond/woff2-rs", rev = "d3d93ea", optional = true, version = "0.3.0" }
+woff2 = { git = "https://github.com/zimond/woff2-rs", rev = "d3d93ea", optional = true }
 
 [target.'cfg(not(all(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 walkdir = "2.3.1"

--- a/src/ras.rs
+++ b/src/ras.rs
@@ -2,7 +2,8 @@ use crate::metrics::CharMetrics;
 use crate::*;
 use ab_glyph_rasterizer::{Point as AbPoint, Rasterizer};
 use pathfinder_content::outline::{Contour, ContourIterFlags, Outline};
-use pathfinder_content::stroke::{LineCap, LineJoin, OutlineStrokeToFill, StrokeStyle};
+pub use pathfinder_content::stroke::{LineCap, LineJoin};
+use pathfinder_content::stroke::{OutlineStrokeToFill, StrokeStyle};
 use pathfinder_geometry::vector::Vector2F;
 use ttf_parser::{OutlineBuilder, Rect};
 use usvg::PathData;
@@ -37,7 +38,14 @@ impl Font {
 
     /// Rasterize the outline of a glyph for a certain font_size, and a possible
     /// stroke. This method is costy
-    pub fn bitmap(&self, c: char, font_size: f32, stroke_width: f32) -> Option<GlyphBitmap> {
+    pub fn bitmap(
+        &self,
+        c: char,
+        font_size: f32,
+        stroke_width: f32,
+        line_join: Option<LineJoin>,
+        line_cap: Option<LineCap>,
+    ) -> Option<GlyphBitmap> {
         if !self.has_glyph(c) {
             return None;
         }
@@ -73,8 +81,8 @@ impl Font {
                 &outline,
                 StrokeStyle {
                     line_width: stroke_width / factor,
-                    line_cap: LineCap::default(),
-                    line_join: LineJoin::Miter(4.0),
+                    line_cap: line_cap.unwrap_or(LineCap::default()),
+                    line_join: line_join.unwrap_or(LineJoin::Miter(4.0)),
                 },
             );
             filler.offset();


### PR DESCRIPTION
expose two stroke style param (line-cap, line-join)
may be sometimes need custom the stroke style like SVG [stroke-linecap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap) and stroke-linejoin.
I added two parameters for `Font::bitmap`, set None to use fontkit default.