### PR TITLE
fix(ras): fix stroke broken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ ras = [
     "pathfinder_simd",
     "usvg",
 ]
+optimize_stroke_broken = []
 # wit = ["wit-bindgen-rust", "dashmap"]
 
 [build-dependencies]


### PR DESCRIPTION
fix stroke broken

<img width="1268" alt="fix stroke" src="https://user-images.githubusercontent.com/44860097/209783577-487dfa1b-6334-4b0a-a2af-898a6fcfe19d.png">

to fix this, remove obtuse angle in quadratic bezier curve.
if path's last end point is equal to the first move segment(M) point, stroke width will loss at the last end point.

<img width="1210" alt="Snipaste_2022-12-28_16-34-57" src="https://user-images.githubusercontent.com/44860097/209783687-829ceb83-12d4-4d8d-8737-46038a77b2bf.png">

this pr only remove line-to segment(L) which end point is equal to move segment(M)

I'm not sure if it will affect the correct path, so is't a experimental function.