### PR TITLE
wip: support render png colord emoji

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontkit"
-version = "0.4.6"
+version = "0.5.0-beta.2"
 edition = "2021"
 authors = ["Zimon Dai <daizhuoxian@gmail.com>"]
 description = "A simple library for font loading and indexing"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -274,3 +274,16 @@ pub struct CharMetrics {
     pub height: i16,
     pub missing: bool,
 }
+
+impl CharMetrics {
+    pub(crate) fn mul_factor(&mut self, factor: f32) {
+        self.advanced_x = (self.advanced_x as f32 * factor) as u16;
+        self.units = self.units * factor;
+        self.height = (self.height as f32 * factor) as i16;
+        self.lsb = (self.lsb as f32 * factor) as i16;
+        self.bbox.x_min = (self.bbox.x_min as f32 * factor) as i16;
+        self.bbox.x_max = (self.bbox.x_max as f32 * factor) as i16;
+        self.bbox.y_min = (self.bbox.y_min as f32 * factor) as i16;
+        self.bbox.y_max = (self.bbox.y_max as f32 * factor) as i16;
+    }
+}

--- a/src/ras.rs
+++ b/src/ras.rs
@@ -76,7 +76,8 @@ impl Font {
             ascender: a as f32 * factor,
             descender: d as f32 * factor,
             advanced_x,
-            buffer: bb.data.to_vec(),
+            data: bb.data.to_vec(),
+            rgba_buf: None,
         }))
     }
 
@@ -383,7 +384,8 @@ pub struct GlyphBitmapPNG {
     pub ascender: f32,
     pub descender: f32,
     pub advanced_x: f32,
-    pub buffer: Vec<u8>,
+    pub data: Vec<u8>,
+    pub rgba_buf: Option<Vec<u8>>,
 }
 
 impl GlyphBitmap {
@@ -464,10 +466,10 @@ impl GlyphBitmap {
         }
     }
 
-    pub fn bitmap(&self) -> &Vec<u8> {
+    pub fn bitmap(&self) -> Option<&Vec<u8>> {
         match self {
-            GlyphBitmap::GrayScale(g) => &g.bitmap,
-            GlyphBitmap::PNG(g) => &g.buffer,
+            GlyphBitmap::GrayScale(g) => Some(&g.bitmap),
+            GlyphBitmap::PNG(g) => g.rgba_buf.as_ref().and_then(|buf| Some(buf)),
         }
     }
 


### PR DESCRIPTION
* GlyphBitmap changed to Enum and supported the  type 
* add bitmap_png function, to create GlyphBitmap::PNG
* add emoji_font_key used to determine whether char is an emoji
* Only support for NotoColorEmoji was tested

```rust
let mut fontkit = FontKit::new();
let emoji = FontKey::new_with_family("Noto Color Emoji".to_string());
fontkit.set_emoji(emoji);
```